### PR TITLE
FIX - Properly create mount directories for volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ansible/clusters/test-cluster

--- a/ansible/roles/digital-ocean/tasks/main.yml
+++ b/ansible/roles/digital-ocean/tasks/main.yml
@@ -6,9 +6,10 @@
       ansible.builtin.file:
         path: "{{ item.mount_point }}"
         state: directory
+        recurse: yes
       with_items: "{{ digital_ocean_volumes }}"
       when: digital_ocean_volumes is defined
-      
+
     # TO DO - CHECK IF FILE SYSTEM NEEDS FORMATING
     # - name: Format volume
     #   mkfs:

--- a/ansible/roles/digital-ocean/tasks/main.yml
+++ b/ansible/roles/digital-ocean/tasks/main.yml
@@ -2,20 +2,13 @@
 - name: Initialize Digital Ocean volumes if configured
   when: digital_ocean_volumes is defined
   block:
-    - name: check if mountpoints exist
-      stat: 
+    - name: Create mount point if does not exist
+      ansible.builtin.file:
         path: "{{ item.mount_point }}"
-      register: digital_ocean_volume_mounts
+        state: directory
       with_items: "{{ digital_ocean_volumes }}"
       when: digital_ocean_volumes is defined
-
-    - name: Create mount point for volume
-      file: 
-        path: "{{ item.item }}"
-        state: directory
-      with_items: "{{ digital_ocean_volume_mounts.results }}"
-      when: not item.stat.exists
-
+      
     # TO DO - CHECK IF FILE SYSTEM NEEDS FORMATING
     # - name: Format volume
     #   mkfs:

--- a/ansible/roles/hetzner/tasks/main.yml
+++ b/ansible/roles/hetzner/tasks/main.yml
@@ -8,9 +8,9 @@
       ansible.builtin.file:
         path: "{{ item.mount_point }}"
         state: directory
+        recurse: yes
       with_items: "{{ hetzner_volume_mounts }}"
       when: hetzner_volume_mounts is defined
-
     # TO DO - CHECK IF FILE SYSTEM NEEDS FORMATING
     # - name: Format volume
     #   mkfs:

--- a/ansible/roles/hetzner/tasks/main.yml
+++ b/ansible/roles/hetzner/tasks/main.yml
@@ -4,18 +4,12 @@
   when: hetzner_volumes is defined
   block:
 
-    - name: check if mountpoints exist
-      stat: 
+    - name: Create mount point if does not exist
+      ansible.builtin.file:
         path: "{{ item.mount_point }}"
-      register: hetzner_volume_mounts
-      with_items: "{{ hetzner_volumes }}"
-
-    - name: Create mount point for volume
-      file: 
-        path: "{{ item.item }}"
         state: directory
-      with_items: "{{ hetzner_volume_mounts.results }}"
-      when: not item.stat.exists
+      with_items: "{{ hetzner_volume_mounts }}"
+      when: hetzner_volume_mounts is defined
 
     # TO DO - CHECK IF FILE SYSTEM NEEDS FORMATING
     # - name: Format volume


### PR DESCRIPTION
It seems that the `Create mount point for volume` task was creating some garbage in the home directory. This tries to use the ansible file built in to create the directory to mount the drives. However I'm not really sure this step is needed, because the provision is working fine, except the garbage it's creating in the home dir.

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html